### PR TITLE
Update map Name textbox with the Seed textbox value when the various Save buttons are used.  Prevents overwriting of previous map when new seed is used.

### DIFF
--- a/src/net/buddat/wgenerator/WGenerator.java
+++ b/src/net/buddat/wgenerator/WGenerator.java
@@ -495,6 +495,7 @@ public class WGenerator extends JFrame implements ActionListener, FocusListener 
 		
 		if (api == null)
 			try {
+                                txtName.setText(txtSeed.getText());
 				api = WurmAPI.create("./maps/" + txtName.getText() + "/", (int) (Math.log(heightMap.getMapSize()) / Math.log(2)));
 				apiClosed = false;
 			} catch (IOException e) {
@@ -869,6 +870,7 @@ public class WGenerator extends JFrame implements ActionListener, FocusListener 
 			
 			MapData map = getAPI().getMapData();
 			try {
+                                txtName.setText(txtSeed.getText());
 				ImageIO.write(map.createMapDump(), "png", new File("./maps/" + txtName.getText() + "/map.png"));
 				ImageIO.write(map.createTopographicDump(true, (short) 250), "png", new File("./maps/" + txtName.getText() + "/topography.png"));
 				ImageIO.write(map.createCaveDump(true), "png", new File("./maps/" + txtName.getText() + "/cave.png"));
@@ -897,6 +899,7 @@ public class WGenerator extends JFrame implements ActionListener, FocusListener 
 			}
 			
 			try {
+                                txtName.setText(txtSeed.getText());
 				File actionsFile = new File("./maps/" + txtName.getText() + "/map_actions.txt");
 				actionsFile.createNewFile();
 				
@@ -932,9 +935,7 @@ public class WGenerator extends JFrame implements ActionListener, FocusListener 
 		}
 		
 		if (e.getSource() == btnResetHeightSeed) {
-                        long newSeed = System.currentTimeMillis();
-			txtSeed.setText("" + newSeed);
-                        txtName.setText("" + newSeed);
+			txtSeed.setText("" + System.currentTimeMillis());
 		}
 		
 		if (e.getSource() == btnResetBiomeSeed) {

--- a/src/net/buddat/wgenerator/WGenerator.java
+++ b/src/net/buddat/wgenerator/WGenerator.java
@@ -932,7 +932,9 @@ public class WGenerator extends JFrame implements ActionListener, FocusListener 
 		}
 		
 		if (e.getSource() == btnResetHeightSeed) {
-			txtSeed.setText("" + System.currentTimeMillis());
+                        long newSeed = System.currentTimeMillis();
+			txtSeed.setText("" + newSeed);
+                        txtName.setText("" + newSeed);
 		}
 		
 		if (e.getSource() == btnResetBiomeSeed) {


### PR DESCRIPTION
It now updates the Name textbox when the Save Map, Save Images, or Save Actions buttons are pressed.
